### PR TITLE
Retain category short-codes.

### DIFF
--- a/src/texttojson.ts
+++ b/src/texttojson.ts
@@ -9,7 +9,7 @@ import minimist from "minimist"
 
 const expect = chai.expect
 
-const categoryPattern = new RegExp(/^\w\w - (.*)$/)
+const categoryPattern = new RegExp(/^(\w\w - .*)$/)
 const subCategoryPattern = new RegExp(/^\d\d\d - (.*)$/)
 const personEndPattern = new RegExp(/\$[\d.,]+$/)
 const salaryPattern = new RegExp(/([\d.]+) ([\d.]+) \$([\d.,]+) \$([\d.,]+)$/)


### PR DESCRIPTION
Retain short-codes in category names to allow for downstream analysis based on campuses.

Alternatively, could make short-code its own attribute, but keeping it together with the name would help guard against grouping by departments that share names across campuses.

Some spot-checks suggest that not all short-codes are explained in the current TOC.